### PR TITLE
adds `exclude-snippet` implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,26 @@ Just change the first line of it as follows:
   </transform-results>
 ```
 
-Note: `perferred-elements` will effectively be ignored. You can omit that.
+Note: `preferred-elements` will effectively be ignored. You can omit that.
 
 Note also: Flattening the document would cause range- and value-queries, to no longer match and giving no highlights. To counteract this snippeting adds a word-query for all values. That might highlight too much, but better than nothing.
+
+## exclude-snippet
+
+A snippeting function that excludes elements or JSON properties by name. Uses a new `excluded-matches` configuration element that takes the same configuration as `preferred-elements`. (An `excluded-elements` config element is also available; it only works with XML elements).
+
+All other `transform-results` configuration options are supported.
+
+```xml
+  <transform-results apply="snippet" ns="http://marklogic.com/exclude-snippet" at="/ext/mlpm_modules/ml-snippeting/exclude-snippet.xqy">
+    <excluded-matches>
+      <json-property>ssn</json-property>
+      <json-property>triple</json-property>
+      <element ns="" name="ssn"/>
+      <element ns="http://marklogic.com/semantics" name="triple"/>
+    </excluded-matches>
+    <max-matches>1</max-matches>
+    <max-snippet-chars>150</max-snippet-chars>
+    <per-match-tokens>20</per-match-tokens>
+  </transform-results>
+```

--- a/exclude-snippet.xqy
+++ b/exclude-snippet.xqy
@@ -1,0 +1,101 @@
+xquery version "1.0-ml";
+
+(:~
+ : A snippeting function that excludes elements or JSON properties by name
+ :
+ : @author Joe Bryan
+ :)
+
+module namespace snip = "http://marklogic.com/exclude-snippet";
+
+import module namespace search = "http://marklogic.com/appservices/search"
+  at "/MarkLogic/appservices/search/search.xqy";
+import module namespace search-impl = "http://marklogic.com/appservices/search-impl"
+  at "/MarkLogic/appservices/search/search-impl.xqy";
+
+declare option xdmp:mapping "false";
+
+(:~ reconstruct a JSON node, excluding properties by name :)
+declare %private function snip:exclude-json($x as item(), $excluded as xs:string*)
+{
+  typeswitch($x)
+  case document-node() return
+    snip:exclude-json($x/node(), $excluded)
+  case object-node()|array-node() return
+    xdmp:to-json(
+      snip:exclude-json(xdmp:from-json($x), $excluded))
+  case json:array return
+    (: TODO: preserve null / sparse arrays :)
+    for $val in json:array-values($x)
+    return snip:exclude-json($val, $excluded)
+  case json:object return
+    (: TODO: preserve property order :)
+    map:new((
+      for $key in map:keys($x)
+      return
+        if ($key = $excluded) then ()
+        else
+          map:entry($key,
+            snip:exclude-json(map:get($x, $key), $excluded))))
+  default return $x
+};
+
+(:~ reconstruct an XML node, excluding properties by QName :)
+declare %private function snip:exclude-element($x as item(), $excluded as xs:QName*)
+{
+  typeswitch($x)
+  case document-node() return
+    snip:exclude-element($x/node(), $excluded)
+  case element() return
+    if (fn:node-name($x) = $excluded) then ()
+    else
+      element { fn:node-name($x) } {
+        $x/@*,
+        $x/node() ! snip:exclude-element(., $excluded)
+      }
+  default return $x
+};
+
+(:~
+ : reconstruct a node, excluding elements or JSON properties by name,
+ : as specified in <search:transform-results/> options:
+ :
+ :  <code>
+ :  &lt;transform-results apply="snippet"
+ :                     ns="http://marklogic.com/exclude-snippet"
+ :                     at="/ext/mlpm_modules/ml-snippeting/exclude-snippet.xqy">
+ :    &lt;excluded-matches>
+ :      &lt;json-property>json-secret&lt;/json-property>
+ :      &lt;element ns="http://domain.com/ns" name="xml-secret"/>
+ :    &lt;/excluded-matches>
+ :  &lt;/transform-results>
+ : </code>
+ :)
+declare %private function snip:process-excludes(
+  $x as node(),
+  $options as element(search:transform-results)?
+)
+{
+  if (fn:exists($x/(self::object-node()|self::array-node()|
+                    child::object-node()|child::array-node())))
+  then
+    snip:exclude-json($x,
+      $options/search:excluded-matches/search:json-property/fn:string())
+  else
+    snip:exclude-element($x,
+      $options/(search:excluded-elements|search:excluded-matches)
+        /search:element/search-impl:spec-qname(.))
+};
+
+declare function snip:snippet(
+  $result as node()?,
+  $ctsquery as schema-element(cts:query),
+  $options as element(search:transform-results)?
+) as element(search:snippet)
+{
+  search:snippet(
+    snip:process-excludes($result, $options),
+    $ctsquery,
+    $options
+  )
+};


### PR DESCRIPTION
Adds a custom snippet function for excluding element or JSON properties from snippets.

Note, this currently works by reconstructing the full `$result` node tree before snippet-ing. This could be slow for large trees.

Deficiencies: 
- doesn't preserve `null-node()` in JSON arrays
- doesn't preserve JSON property order
